### PR TITLE
chore(security): enable Renovate for GitHub Actions SHA pinning

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,0 +1,4 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["github>wandb/renovate-config"]
+}

--- a/README.md
+++ b/README.md
@@ -99,12 +99,12 @@ No modules.
 
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
-| <a name="input_additional_target_namespaces"></a> [additional\_target\_namespaces](#input\_additional\_target\_namespaces) | Additional target namespaces that the launch agent can deploy into | `list(string)` | <pre>[<br>  "wandb",<br>  "default"<br>]</pre> | no |
+| <a name="input_additional_target_namespaces"></a> [additional\_target\_namespaces](#input\_additional\_target\_namespaces) | Additional target namespaces that the launch agent can deploy into | `list(string)` | <pre>[<br/>  "wandb",<br/>  "default"<br/>]</pre> | no |
 | <a name="input_agent_api_key"></a> [agent\_api\_key](#input\_agent\_api\_key) | W&B API key | `string` | n/a | yes |
 | <a name="input_agent_image"></a> [agent\_image](#input\_agent\_image) | Container image to use for the agent | `string` | n/a | yes |
 | <a name="input_agent_image_pull_policy"></a> [agent\_image\_pull\_policy](#input\_agent\_image\_pull\_policy) | Image pull policy for agent image | `string` | `"Always"` | no |
 | <a name="input_agent_labels"></a> [agent\_labels](#input\_agent\_labels) | Agent labels | `map(string)` | `{}` | no |
-| <a name="input_agent_resources"></a> [agent\_resources](#input\_agent\_resources) | Resources block for the agent spec | <pre>object({<br>    limits = map(string)<br>  })</pre> | <pre>{<br>  "limits": {<br>    "cpu": "1",<br>    "memory": "1Gi"<br>  }<br>}</pre> | no |
+| <a name="input_agent_resources"></a> [agent\_resources](#input\_agent\_resources) | Resources block for the agent spec | <pre>object({<br/>    limits = map(string)<br/>  })</pre> | <pre>{<br/>  "limits": {<br/>    "cpu": "1",<br/>    "memory": "1Gi"<br/>  }<br/>}</pre> | no |
 | <a name="input_azure_storage_access_key"></a> [azure\_storage\_access\_key](#input\_azure\_storage\_access\_key) | Set to access key for azure storage if using kaniko with azure | `string` | `""` | no |
 | <a name="input_base_url"></a> [base\_url](#input\_base\_url) | W&B api url | `string` | n/a | yes |
 | <a name="input_git_creds"></a> [git\_creds](#input\_git\_creds) | The contents of a git credentials file | `string` | `""` | no |


### PR DESCRIPTION
## Required: enable Renovate for GitHub Actions SHA pinning

This PR is part of an AppSec-mandated rollout enabling SHA-pinned GitHub Actions across the wandb organization. All targeted repos are required to merge.

## What this PR does

Adds `.github/renovate.json5` extending a shared Renovate preset. Renovate runs centrally on a daily cron — no workflow file added to your repo.

## Why this is mandatory

GitHub Actions tags can be silently repointed by attackers. The `tj-actions/changed-files` compromise (March 2025) and the `aquasecurity/trivy-action` incident (March 2026) are well-documented examples of this attack pattern. Pinning every `uses:` reference to a 40-char commit SHA eliminates this attack vector.

## What happens after you merge

Within ~24 hours, an automated follow-up PR opens from `wandb-renovate[bot]` that pins every `uses: action@<tag>` reference in your workflows to a 40-char commit SHA. Version tags are preserved as trailing comments so diffs stay readable.

Going forward:

- Patch/minor SHA bumps: auto-PR after a 7-day release-age wait
- Major bumps: surfaced on the repo's Dependency Dashboard issue, opt-in
- Other dep managers (pip, terraform, docker): not touched

## Required action

1. Merge this PR
2. Merge the follow-up SHA-pin PR from `wandb-renovate[bot]` (opens within 24 hours)
3. Merge ongoing SHA-bump PRs from `wandb-renovate[bot]` as they appear

## Technical blockers

If you have a concrete technical blocker (e.g. workflows referencing internal-only refs that can't be SHA-pinned), reach out to `@coreweave/application-security` so we can work through it together.

[_Created by Sourcegraph batch change `shivawandb/enable-renovate-wandb-org-public`._](https://coreweave.sourcegraphcloud.com/users/shivawandb/batch-changes/enable-renovate-wandb-org-public)